### PR TITLE
Switch GA fitness to climbing height

### DIFF
--- a/src/creature.py
+++ b/src/creature.py
@@ -40,6 +40,7 @@ class Creature:
         self.motors = None
         self.start_position = None
         self.last_position = None
+        self.max_z = None
 
     def get_flat_links(self):
         if self.flat_links == None:
@@ -88,10 +89,13 @@ class Creature:
         return self.motors 
     
     def update_position(self, pos):
-        if self.start_position == None:
+        if self.start_position is None:
             self.start_position = pos
+            self.max_z = pos[2]
         else:
             self.last_position = pos
+            if self.max_z is None or pos[2] > self.max_z:
+                self.max_z = pos[2]
 
     def get_distance_travelled(self):
         if self.start_position is None or self.last_position is None:
@@ -99,7 +103,12 @@ class Creature:
         p1 = np.asarray(self.start_position)
         p2 = np.asarray(self.last_position)
         dist = np.linalg.norm(p1-p2)
-        return dist 
+        return dist
+
+    def get_height_climbed(self):
+        if self.start_position is None or self.max_z is None:
+            return 0
+        return self.max_z - self.start_position[2]
 
     def update_dna(self, dna):
         self.dna = dna
@@ -108,3 +117,5 @@ class Creature:
         self.motors = None
         self.start_position = None
         self.last_position = None
+        self.max_z = None
+

--- a/src/test_creature.py
+++ b/src/test_creature.py
@@ -46,13 +46,13 @@ class TestCreature(unittest.TestCase):
         m.get_output()     
         self.assertGreater(m.get_output(), 0)
     
-    def testDist(self):
+    def testHeight(self):
         c = creature.Creature(3)
         c.update_position((0, 0, 0))
-        d1 = c.get_distance_travelled()
-        c.update_position((1, 1, 1))
-        d2 = c.get_distance_travelled()
-        self.assertGreater(d2, d1)
+        h1 = c.get_height_climbed()
+        c.update_position((1, 1, 2))
+        h2 = c.get_height_climbed()
+        self.assertGreater(h2, h1)
         
 
 unittest.main()

--- a/src/test_ga.py
+++ b/src/test_ga.py
@@ -20,7 +20,7 @@ class TestGA(unittest.TestCase):
 
         for iteration in range(1000):
             sim.eval_population(pop, 2400)
-            fits = [cr.get_distance_travelled() 
+            fits = [cr.get_height_climbed()
                     for cr in pop.creatures]
             links = [len(cr.get_expanded_links()) 
                     for cr in pop.creatures]
@@ -44,7 +44,7 @@ class TestGA(unittest.TestCase):
             # elitism
             max_fit = np.max(fits)
             for cr in pop.creatures:
-                if cr.get_distance_travelled() == max_fit:
+                if cr.get_height_climbed() == max_fit:
                     new_cr = creature.Creature(1)
                     new_cr.update_dna(cr.dna)
                     new_creatures[0] = new_cr

--- a/src/test_ga_no_threads.py
+++ b/src/test_ga_no_threads.py
@@ -25,7 +25,7 @@ class TestGA(unittest.TestCase):
             for cr in pop.creatures:
                 sim.run_creature(cr, 2400)            
             #sim.eval_population(pop, 2400)
-            fits = [cr.get_distance_travelled() 
+            fits = [cr.get_height_climbed()
                     for cr in pop.creatures]
             links = [len(cr.get_expanded_links()) 
                     for cr in pop.creatures]
@@ -49,7 +49,7 @@ class TestGA(unittest.TestCase):
             # elitism
             max_fit = np.max(fits)
             for cr in pop.creatures:
-                if cr.get_distance_travelled() == max_fit:
+                if cr.get_height_climbed() == max_fit:
                     new_cr = creature.Creature(1)
                     new_cr.update_dna(cr.dna)
                     new_creatures[0] = new_cr

--- a/src/test_simulation.py
+++ b/src/test_simulation.py
@@ -27,9 +27,9 @@ class TestSim(unittest.TestCase):
         sim = simulation.Simulation()
         for cr in pop.creatures:
             sim.run_creature(cr)
-        dists = [cr.get_distance_travelled() for cr in pop.creatures]
-        print(dists)
-        self.assertIsNotNone(dists)
+        heights = [cr.get_height_climbed() for cr in pop.creatures]
+        print(heights)
+        self.assertIsNotNone(heights)
 
 ## uncomment this to test the 
 ## multi-threaded sim
@@ -45,8 +45,8 @@ class TestSim(unittest.TestCase):
         pop = population.Population(pop_size=20, gene_count=3)
         sim = simulation.Simulation()
         sim.eval_population(pop, 2400)
-        dists = [cr.get_distance_travelled() for cr in pop.creatures]
-        print(dists)
-        self.assertIsNotNone(dists)
+        heights = [cr.get_height_climbed() for cr in pop.creatures]
+        print(heights)
+        self.assertIsNotNone(heights)
 
 unittest.main()


### PR DESCRIPTION
## Summary
- track max altitude in `Creature`
- compute fitness using `get_height_climbed`
- update GA and simulation tests to use height instead of distance
- adjust creature unit tests for height climbing

## Testing
- `python3 src/test_creature.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python3 src/test_simulation.py` *(fails: ModuleNotFoundError: No module named 'pybullet')*

------
https://chatgpt.com/codex/tasks/task_e_685285ab5800832e8e58e7614354efc3